### PR TITLE
feat: add project name to Docker Compose for isolated environments

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,4 @@
+name: ${APP_ENV}
 services:
   frontend:
     depends_on:


### PR DESCRIPTION
Previously, running multiple environments (e.g., production and staging) with the same `docker-compose` file caused containers from one environment to replace those from another. This happened because Docker Compose treated them as part of the same project due to the shared file name.

To fix this, we now set the `name` field in `docker-compose.yaml` using `${APP_ENV}`, ensuring that each environment gets a unique project name. This prevents conflicts and allows production and staging containers to run simultaneously without interfering with each other.

Additionally, this approach improves visibility by defining the project name directly in the compose file rather than relying on the CLI `--project-name` option.